### PR TITLE
docs(README): Fix quickstart instructions & add pointer to build docs (#2)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,8 @@ Then:
 [source,shell]
 ----
 cd new-presentation/
-make Gemfile Gemfile.lock
-bundle update
+make Gemfile
+bundle
 ----
 
 == Updating the Reveal.js calconnect.css Stylesheet

--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,7 @@ Then:
 [source,shell]
 ----
 cd new-presentation/
+make Gemfile Gemfile.lock
 bundle update
 ----
 
@@ -46,3 +47,7 @@ popd
 cp reveal.js/css/theme/ribose.css revealjs-css/
 ----
 
+== Rendering the Presentation
+
+You can build an interactive Reveal.js presentation or a set of slides in PDF.
+Refer to README inside presentation directory on details.


### PR DESCRIPTION
@ronaldtse checking just in case, presentation user is supposed to run `make Gemfile` to make `bundle update` work, right? (That did the trick for me at least.)

I know it’s the legacy flow we’re getting rid of, had to see how it works now though.

(#2)